### PR TITLE
Set attributes to header elements without requiring backgrid patch

### DIFF
--- a/backgrid-grouped-columns.js
+++ b/backgrid-grouped-columns.js
@@ -69,7 +69,7 @@
       var lastNesting = [];
       self.columns.each(function (column) {
         var colNesting = (self.group) ? column.get("nesting") : [];
-        var renderable = (typeof column.get("renderable") == "undefined" || column.get("renderable"));
+        var renderable = (typeof column.get("renderable") === "undefined" || column.get("renderable"));
         if (colNesting && !_.isEmpty(colNesting) && renderable) {
           // Add index to colname for proper comparison for unique and different entries
           var colNestingIndex = _.map(colNesting, function (nest, ind) {
@@ -142,6 +142,13 @@
         });
         self.$el.append(row.render().$el);
         self.headerRows.push(row);
+      });
+      
+      // Set attributes. Loop cells of rows.
+      _.each(self.headerRows, function(headerRow) {
+        _.each(headerRow.cells, function(cell) {
+          cell.$el.prop(cell.column.get("attributes"));
+        });
       });
 
       // Attach row object to object to ensure compatibility with other plugins.


### PR DESCRIPTION
This change make the backgrid patch for the header cell obsolete. It's also more reliable when using other third party solutions.